### PR TITLE
Add fields needed by crates.io.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "packedvec"
+description = "Store vectors of integers efficiently"
 version = "1.0.0"
 authors = ["Gabriela Alexandra Moldovan <gabi_250@live.com>", "Laurence Tratt <http://tratt.net/laurie/>"]
 readme = "README.md"
 # This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
 # UPL-1.0.
 license = "Apache-2.0 OR MIT"
+categories = ["data-structures"]
 
 [dependencies]
 num-traits = "0.2"


### PR DESCRIPTION
I forgot that https://crates.io/ requires fields in the `Cargo.toml` file that one otherwise can get away without. Oops!