### PR TITLE
Add a link to the github repository.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "packedvec"
 description = "Store vectors of integers efficiently"
+repository = "https://github.com/softdevteam/packedvec/"
 version = "1.0.0"
 authors = ["Gabriela Alexandra Moldovan <gabi_250@live.com>", "Laurence Tratt <http://tratt.net/laurie/>"]
 readme = "README.md"


### PR DESCRIPTION
This isn't strictly necessary, but it's a nice-to-have. I won't make a 1.0.1 release just for this, but it'll pop up naturally when we make the next release of packedvec.