### PR TITLE
Prepare for a 1.1.0 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# packedvec 1.1.0 (2018-10-17)
+
+* Add `bwidth` function.
+* Add `Eq`, `PartialEq`, and `Hash` implementations for `PackedVec`.
+
 # packedvec 1.0.0 (2018-10-15)
 
 First stable release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "packedvec"
 description = "Store vectors of integers efficiently"
 repository = "https://github.com/softdevteam/packedvec/"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Gabriela Alexandra Moldovan <gabi_250@live.com>", "Laurence Tratt <http://tratt.net/laurie/>"]
 readme = "README.md"
 # This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about


### PR DESCRIPTION
I don't have anything else on my mind for `packedvec`, so make another release while I think on it.