### PR TITLE
Make rand a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,7 @@ categories = ["data-structures"]
 
 [dependencies]
 num-traits = "0.2"
-rand = "0.3"
 serde = { version="1.0", features=["derive"], optional=true }
+
+[dev-dependencies]
+rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 //! struct.
 
 extern crate num_traits;
-extern crate rand;
 
 #[cfg(feature = "serde")]
 #[macro_use]
@@ -374,8 +373,9 @@ fn i_log2<T: PrimInt + Unsigned>(n: T) -> usize {
 
 #[cfg(test)]
 mod tests {
+    extern crate rand;
+    use self::rand::Rand;
     use super::*;
-    use rand::Rand;
 
     #[test]
     fn empty_vec() {


### PR DESCRIPTION
This avoids having to build `rand` including its dependency `libc` when
using the packedvec crate.