### PR TITLE
Add get_unchecked function.

### DIFF
--- a/benches/packedvec.rs
+++ b/benches/packedvec.rs
@@ -14,7 +14,7 @@ extern crate rand;
 extern crate test;
 
 use packedvec::*;
-use test::Bencher;
+use test::{black_box, Bencher};
 
 #[bench]
 fn creation(bench: &mut Bencher) {
@@ -33,4 +33,36 @@ fn iteration(bench: &mut Bencher) {
     }
     let pv = PackedVec::new(v);
     bench.iter(|| pv.iter().collect::<Vec<_>>());
+}
+
+#[bench]
+fn get(bench: &mut Bencher) {
+    let mut v = vec![];
+    for _ in 0..100 {
+        for i in 0..1000u16 {
+            v.push(i);
+        }
+    }
+    let pv = PackedVec::new(v);
+    bench.iter(|| {
+        for i in 0..pv.len() {
+            black_box(pv.get(i));
+        }
+    });
+}
+
+#[bench]
+fn get_unchecked(bench: &mut Bencher) {
+    let mut v = vec![];
+    for _ in 0..100 {
+        for i in 0..1000u16 {
+            v.push(i);
+        }
+    }
+    let pv = PackedVec::new(v);
+    bench.iter(|| {
+        for i in 0..pv.len() {
+            black_box(unsafe { pv.get_unchecked(i) });
+        }
+    });
 }


### PR DESCRIPTION
This is modelled on the `get_unchecked` function found in Vec and slices, and is unsafe because it doesn't perform bounds checking. In the best case (a linear scan through a PackedVec), this is about 10% faster than normal `get()` as can be seen from the two new benchmarks:

```
  test creation      ... bench:      25,231 ns/iter (+/- 4,377)
  test get           ... bench:     272,911 ns/iter (+/- 2,475)
  test get_unchecked ... bench:     243,155 ns/iter (+/- 659)
  test iteration     ... bench:      31,245 ns/iter (+/- 89)
```

where "get" is checked and "get_unchecked" is unchecked.

After performing a bounds check, `get()` now calls `get_unchecked()`; internally, `get_unchecked()` calls `Vec::get_unchecked()`. Since our our `iter()` implementation calls `get()`, it happens to hit the best case (since it's a linear scan) as can be seen from these timings from the "pre-get_unchecked" case:

```
  test creation  ... bench:      25,119 ns/iter (+/- 904)
  test iteration ... bench:      35,984 ns/iter (+/- 58)
```

So even though not many people will be brave enough to call `get_unchecked()` directly (though I have code that will!), anyone using iteration gets its performance benefits for free!