### PR TITLE
s/Garbiela/Gabriela in license.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Garbiela Alexandra Moldovan
+// Copyright (c) 2017 Gabriela Alexandra Moldovan
 // Copyright (c) 2018 King's College London created by the Software Development Team
 // <http://soft-dev.org/>
 //


### PR DESCRIPTION
Not a big deal, but I wanted to use the license from here for `k2` as well, and I realised my name was spelled incorrectly.