### PR TITLE
Fix signed delta

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@ where
     if min >= T::zero() {
         (max - min).as_()
     } else if min < T::zero() && max < T::zero() {
-        abs(max) - abs(min)
+        abs(max - min)
     } else {
         debug_assert!(min < T::zero());
         max.as_() + abs(min)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,6 +611,7 @@ mod tests {
         assert_eq!(delta::<u8, u8>(0, u8::max_value()), u8::max_value());
         assert_eq!(delta::<i8, u8>(-2, 0), 2);
         assert_eq!(delta::<i8, u8>(-2, 2), 4);
+        assert_eq!(delta::<i8, u8>(-2, -1), 1);
         assert_eq!(delta::<i8, u8>(i8::min_value(), 0), 128);
         assert_eq!(delta::<i8, u8>(0, i8::max_value()), 127);
         assert_eq!(
@@ -636,6 +637,7 @@ mod tests {
         assert_eq!(inv_delta::<u8, u8>(0, u8::max_value()), u8::max_value());
         assert_eq!(inv_delta::<i8, u8>(-2, 2), 0);
         assert_eq!(inv_delta::<i8, u8>(-2, 4), 2);
+        assert_eq!(inv_delta::<i8, u8>(-2, 1), -1);
         assert_eq!(inv_delta::<i8, u8>(i8::min_value(), 128), 0);
         assert_eq!(inv_delta::<i8, u8>(0, 127), i8::max_value());
         assert_eq!(
@@ -676,6 +678,9 @@ mod tests {
             pv.iter().collect::<Vec<_>>(),
             vec![i32::min_value(), i32::max_value()]
         );
+
+        let pv = PackedVec::new(vec![-2, -1, 0]);
+        assert_eq!(pv.iter().collect::<Vec<_>>(), vec![-2, -1, 0]);
     }
 
     #[test]


### PR DESCRIPTION
Currently, constructing a new `PackedVec` from a vector like `vec![-2, -1, 0]` does not work properly. The reason lies in the computation of `delta` for both negative `min` and `max` arguments.
E.g. `delta(-2, -1) ` is `abs(max) - abs(min)` which, in this case, overflows since `abs(-1) - abs(-2) == -1` is negative but `StorageT` is bound to be `Unsigned`.

This PR addresses this by computing `delta` as `abs(max - min)` instead.
Corresponding test cases are added as well. From what I can tell, `inv_delta` was already working correctly as illustrated by a new test case.
Please let me know if I missed important details.