### PR TITLE
Since bincode is unmaintained use wincode instead.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ categories = ["data-structures"]
 [dependencies]
 num-traits = "0.2"
 serde = { version="1.0", features=["derive"], optional=true }
-bincode = { version="2.0", features=["derive"], optional=true }
+wincode = { version="0.5.5", features=["derive"], optional=true }
 
 [dev-dependencies]
 rand = "0.3"
+
+[features]
+bincode = ["dep:wincode"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ extern crate serde;
 
 #[cfg(feature = "bincode")]
 #[macro_use]
-extern crate bincode;
+extern crate wincode;
 
 use num_traits::{cast::FromPrimitive, AsPrimitive, PrimInt, ToPrimitive, Unsigned};
 use std::{
@@ -55,7 +55,7 @@ use std::{
 /// superior.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
+#[cfg_attr(feature = "bincode", derive(SchemaRead, SchemaWrite))]
 pub struct PackedVec<T, StorageT = usize> {
     len: usize,
     bits: Vec<StorageT>,


### PR DESCRIPTION
This is part of a series of patches to various crates moving from the bincode crate to the wincode crate.
I believe the reverse order of dependencies is:

1. packedvec
2. sparsevec
3. vob
4. grmtools

I'm currently leaving how we want to deal with semver up in the air. Since these do change trait impls around,
It may be that as we release these we need to fiddle with the version numbers in `Cargo.toml` too.

