### PR TITLE
Remove travis-ci badges from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://api.travis-ci.org/softdevteam/packedvec.svg?branch=master)](https://travis-ci.org/softdevteam/packedvec)
 [![Latest version](https://img.shields.io/crates/v/packedvec.svg)](https://crates.io/crates/packedvec)
 [![Documentation](https://docs.rs/packedvec/badge.svg)](https://docs.rs/packedvec)
 


### PR DESCRIPTION
Following https://github.com/softdevteam/grmtools/pull/653 It occurred to me I should check some more repos.

The travis-ci badge wasn't rendering, and clicking the it showed a progress indicator that seemed to spin indefinitely.
I'm assuming that like vob these repositories no longer reply on travis.